### PR TITLE
ユーザーが Ctrl+C でデバッガーに降りられないように端末を RAW モードにする。

### DIFF
--- a/io-linux.lisp
+++ b/io-linux.lisp
@@ -56,7 +56,8 @@
   (cl-charms/low-level:initscr)
   (cl-charms/low-level:scrollok cl-charms/low-level:*stdscr* 1)
   (cl-charms/low-level:keypad cl-charms/low-level:*stdscr* 1)
-(exit-hooks:add-exit-hook #'cl-charms/low-level:endwin))
+  (cl-charms/low-level:raw)
+  (exit-hooks:add-exit-hook #'cl-charms/low-level:endwin))
 
 ;;移動先選択
 (defun map-move (map p)


### PR DESCRIPTION
(raw) が実行される前に Ctrl+C を押されるとデバッガーが起動するかもしれませんので完全な解法ではないですが。