### PR TITLE
init-data で *lv-exp* を 100 にリセットするようにした

### DIFF
--- a/orc-battle.lisp
+++ b/orc-battle.lisp
@@ -39,7 +39,8 @@
 	*end* 0
 	*ha2ne2* nil
 	*start-time* (get-internal-real-time)
-	*battle?* nil))
+	*battle?* nil
+	*lv-exp* 100))
 
 ;;バトル開始
 (defun orc-battle (p)


### PR DESCRIPTION
もう一度挑戦した時に *lv-exp* が 100 よりも大きな値になったままレベルが 1 に戻されるので、経験値100でレベル2に上がらないのを直しました。