### PR TITLE
マップ生成で行き止まりが1つしかできなかった時、処理が停止しなかったのを修正。

### DIFF
--- a/maze-test.lisp
+++ b/maze-test.lisp
@@ -112,6 +112,13 @@
 	     starty (+ (* y 2) 1))
        (setf (aref (donjon-map map) starty startx) 0) ;;初期位置を通路にする
        (recursion starty startx map) ;;迷路生成
+       (loop until (<= 2 (length (donjon-stop-list map)))
+             do
+             ;; 行き止まりが 1 つしか無かったのでやりなおし
+             (init-map (donjon-map map) (donjon-tate map) (donjon-yoko map))
+             (setf (donjon-stop-list map) nil)
+             (setf (aref (donjon-map map) starty startx) 0)
+             (recursion starty startx map))
        (setf (aref (donjon-map map) starty startx) 1) ;;主人公の位置
        (setf (player-posy p) starty
 	     (player-posx p) startx) ;;初期位置


### PR DESCRIPTION
set-boss-kaidan 関数が donjon 構造体の stop-list に座標が2つ以上あることを仮定しているのですが、100 回に1回くらい行き止まりが1つしかない一本道のマップが生成されるようで、このとき、階段とは異なる座標をボス用にランダム選択しようとする処理が停止しないために無限ループになります。

行き止まりが1つしかできなかった場合はマップを掘り直すようにしました。