### PR TITLE
最後のモンスター番号の次の番号を入力すると落ちるのを修正

### DIFF
--- a/orc-battle.lisp
+++ b/orc-battle.lisp
@@ -245,7 +245,7 @@
       (z (auto-pick-monster 0))
       (otherwise
        (let ((x (ascii->number key)))
-	 (if (not (and (integerp x) (>= x 0) (<= x (player-monster-num p))))
+	 (if (not (and (integerp x) (>= x 0) (< x (player-monster-num p))))
 	     (progn (scr-princ "有効なモンスター番号ではありません。")
 		    (pick-monster p))
 	     (let ((m (aref *monsters* x)))


### PR DESCRIPTION
例えば a ~ c までのモンスターが出ているとき、「突く」を選択して d を入力すると落ちていました。